### PR TITLE
Added @MainAnchor annotation

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/iOSPhotoEditor/Protocols.swift
+++ b/Sources/iOSPhotoEditor/Protocols.swift
@@ -14,6 +14,7 @@ import UIKit
  - stickersViewDidDisappear
  */
 
+@MainActor
 public protocol PhotoEditorDelegate: class {
     /**
      - Parameter image: edited Image


### PR DESCRIPTION
The protocol should be annotated with `@MainAnchor` to avoid "Nonisolated protocol requirements" warning in the main app.