### PR TITLE
APP-5860 iOS - Image: App Crash During Image Editing

### DIFF
--- a/Sources/iOSPhotoEditor/PhotoEditor+Controls.swift
+++ b/Sources/iOSPhotoEditor/PhotoEditor+Controls.swift
@@ -249,7 +249,9 @@ extension PhotoEditorViewController {
         for subview in canvasImageView.subviews {
             subview.removeFromSuperview()
         }
-        draw(backupColoredLines)
+        draw { cgContext in
+            drawColoredLines(backupColoredLines, cgContext: cgContext)
+        }
         coloredLines = backupColoredLines
         canResetLines = false
         addControls(animated: false)

--- a/Sources/iOSPhotoEditor/PhotoEditor+Drawing.swift
+++ b/Sources/iOSPhotoEditor/PhotoEditor+Drawing.swift
@@ -40,8 +40,9 @@ extension PhotoEditorViewController {
             swiped = true
             if let touch = touches.first {
                 let currentPoint = touch.location(in: canvasImageView)
-                drawLineFrom(lastPoint, toPoint: currentPoint, withColor: drawColor)
-                
+                draw { cgContext in
+                    drawLineFrom(lastPoint, toPoint: currentPoint, withColor: drawColor, cgContext: cgContext)
+                }
                 guard var lastColoredLine = coloredLines.popLast() else { return }
                 lastColoredLine.append(ColoredPoint(point: currentPoint, color: drawColor))
                 coloredLines.append(lastColoredLine)
@@ -57,43 +58,51 @@ extension PhotoEditorViewController {
         if isDrawing {
             if !swiped {
                 // draw a single point
-                drawLineFrom(lastPoint, toPoint: lastPoint, withColor: drawColor)
+                draw { cgContext in
+                    drawLineFrom(lastPoint, toPoint: lastPoint, withColor: drawColor, cgContext: cgContext)
+                }
             }
         }
         addLineUndoActionRegister()
         manageBarButtonVisibility()
     }
     
-    func draw(_ coloredLines: [coloredLine]) {
+    func draw(drawAction: (CGContext) -> Void) {
+        let canvasSize = canvasImageView.frame.integral.size
+        let renderer = UIGraphicsImageRenderer(size: canvasSize)
+        
+        canvasImageView.image = renderer.image { context in
+            let cgContext = context.cgContext
+            
+            canvasImageView.image?.draw(in: CGRect(origin: .zero, size: canvasSize))
+            
+            cgContext.setLineCap(.round)
+            cgContext.setLineWidth(5.0)
+            cgContext.setBlendMode(.normal)
+            
+            drawAction(cgContext)
+        }
+    }
+    
+    func drawColoredLines(_ coloredLines: [coloredLine], cgContext: CGContext) {
         coloredLines.forEach { line in
             
             for i in 1 ..< line.count {
-                guard let oldPoint = line[i-1].point, let newPoint = line[i].point, let color = line[i].color else { return }
-                drawLineFrom(oldPoint, toPoint: newPoint, withColor: color)
+                guard let oldPoint = line[i-1].point,
+                      let newPoint = line[i].point,
+                      let color = line[i].color
+                else { return }
+                
+                drawLineFrom(oldPoint, toPoint: newPoint, withColor: color, cgContext: cgContext)
             }
         }
     }
     
-    func drawLineFrom(_ fromPoint: CGPoint, toPoint: CGPoint, withColor color: UIColor) {
-        // 1
-        let canvasSize = canvasImageView.frame.integral.size
-        UIGraphicsBeginImageContextWithOptions(canvasSize, false, 0)
-        if let context = UIGraphicsGetCurrentContext() {
-            canvasImageView.image?.draw(in: CGRect(x: 0, y: 0, width: canvasSize.width, height: canvasSize.height))
-            // 2
-            context.move(to: CGPoint(x: fromPoint.x, y: fromPoint.y))
-            context.addLine(to: CGPoint(x: toPoint.x, y: toPoint.y))
-            // 3
-            context.setLineCap( CGLineCap.round)
-            context.setLineWidth(5.0)
-            context.setStrokeColor(color.cgColor)
-            context.setBlendMode(CGBlendMode.normal)
-            // 4
-            context.strokePath()
-            // 5
-            canvasImageView.image = UIGraphicsGetImageFromCurrentImageContext()
-        }
-        UIGraphicsEndImageContext()
+    func drawLineFrom(_ fromPoint: CGPoint, toPoint: CGPoint, withColor color: UIColor, cgContext: CGContext) {
+        cgContext.move(to: fromPoint)
+        cgContext.addLine(to: toPoint)
+        cgContext.setStrokeColor(color.cgColor)
+        cgContext.strokePath()
     }
     
 }
@@ -122,7 +131,9 @@ extension PhotoEditorViewController {
         for subview in canvasImageView.subviews {
             subview.removeFromSuperview()
         }
-        draw(coloredLines)
+        draw { cgContext in
+            drawColoredLines(coloredLines, cgContext: cgContext)
+        }
     }
     
     func addLastLine() {
@@ -133,7 +144,9 @@ extension PhotoEditorViewController {
         for subview in canvasImageView.subviews {
             subview.removeFromSuperview()
         }
-        draw(coloredLines)
+        draw { cgContext in
+            drawColoredLines(coloredLines, cgContext: cgContext)
+        }
     }
 }
 


### PR DESCRIPTION
The app was crashing due to excessive memory consumption:

> The app “HeroDev” has been killed by the operating system because it is using too much memory.

The issue was caused by calling expensive operations (see code snippet) inside a loop instead of executing them just once:

```
if let context = UIGraphicsGetCurrentContext() {
            canvasImageView.image?.draw(in: CGRect(x: 0, y: 0, width: canvasSize.width, height: canvasSize.height))
            ...
}
```

Additionally `UIGraphicsGetCurrentContext` is deprecated and has been replaced by `UIGraphicsImageRenderer` in this PR.